### PR TITLE
feat: ✨ add Open Graph meta tags for improved sharing

### DIFF
--- a/Views/Event/Detail.cshtml
+++ b/Views/Event/Detail.cshtml
@@ -1,7 +1,15 @@
 @model Citlali.Models.EventDetailViewModel;
 
+@{
+    var ogDescription = Model.EventDetailCardData.EventDescription.Length > 100 ? Model.EventDetailCardData.EventDescription.Substring(0, 100) + "..." : Model.EventDetailCardData.EventDescription;
+}
+
 @section head {
     <link rel="stylesheet" href="~/css/Form.css" asp-append-version="true" />
+    <meta property="og:title" content="@Model.EventDetailCardData.EventTitle" />
+    <meta property="og:description" content="@ogDescription" />
+    <meta property="og:url" content="citlali.bigblahaj.com" />
+    <meta property="og:image" content="https://img.4gamers.com.tw/ckfinder-th/image2/auto/2025-01/Citlali_Introduction_Banner-250102-181140.png?versionId=r4yCiZ0mpYQb4la101fQUFNeaAW0mcgl" />
 }
 
 <div class="center-wrapper">

--- a/Views/Shared/_LayoutNav.cshtml
+++ b/Views/Shared/_LayoutNav.cshtml
@@ -14,6 +14,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Thai+Looped:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta perperty="og:title" content="Citlali 🩷" />
+    <meta property="og:description" content="A cute webboard which brings people together~" />
+    <meta property="og:url" content="citlali.bigblahaj.com" />
+    <meta property="og:image" content="https://img.4gamers.com.tw/ckfinder-th/image2/auto/2025-01/Citlali_Introduction_Banner-250102-181140.png?versionId=r4yCiZ0mpYQb4la101fQUFNeaAW0mcgl" />
     <title>@ViewData["Title"] • Citlali</title>
     <script type="importmap"></script>
     <link rel="stylesheet" href="~/css/TailwindDefaults.css" asp-append-version="true" />


### PR DESCRIPTION
This pull request includes updates to add Open Graph metadata to improve social media sharing for the `Event/Detail` and `Shared/_LayoutNav` views. The most important changes are as follows:

Enhancements to social media sharing:

* [`Views/Event/Detail.cshtml`](diffhunk://#diff-c13f9a3d485b5eda7ce179c61d00554ebd2b666dff708d7f3ed87c17b9c9f114R3-R12): Added Open Graph metadata tags for title, description, URL, and image to enhance the sharing experience on social media platforms.
* [`Views/Shared/_LayoutNav.cshtml`](diffhunk://#diff-cd85162bf1a5d6269135a35f163e0f88128c3348317654ca79b25868a9fa7f80R17-R20): Included Open Graph metadata tags for title, description, URL, and image to improve the appearance of shared links on social media.