### PR TITLE
fix: 🐛 user cannot create event

### DIFF
--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -129,18 +129,30 @@ public class UserController : Controller
         var isCurrentUser = currentUser != null && currentUser.Id == user.UserId.ToString();
 
         var userEvents = await _eventService.GetEventsByUserId(user.UserId);
-        var userEventBriefCards = userEvents.Select(e => new EventBriefCardData
+        var userEventBriefCards = new List<EventBriefCardData>();
+        foreach (var userEvent in userEvents)
         {
-            EventId = e.EventId,
-            EventTitle = e.EventTitle,
-            EventDescription = e.EventDescription,
-            CreatedAt = e.CreatedAt,
-            CreatorProfileImageUrl = e.CreatorProfileImageUrl,
-            CreatorDisplayName = e.CreatorDisplayName,
-            CurrentParticipant = e.CurrentParticipant,
-            MaxParticipant = e.MaxParticipant,
-            EventCategoryTag = e.EventCategoryTag
-        }).ToList();
+            var creator = await _userService.GetUserByUserId(userEvent.CreatorUserId);
+            if (creator == null)
+            {
+                continue;
+            }
+
+            var eventTag = await _eventService.GetTagById(userEvent.EventCategoryTagId);
+            var locationTag = await _eventService.GetLocationTagById(userEvent.EventLocationTagId);
+
+
+            userEventBriefCards.Add(new EventBriefCardData
+            {
+                EventId = userEvent.EventId,
+                EventTitle = userEvent.EventTitle,
+                EventDescription = userEvent.EventDescription,
+                CreatorDisplayName = creator.DisplayName,
+                CreatorProfileImageUrl = creator.ProfileImageUrl,
+                EventCategoryTag = eventTag ?? new EventCategoryTag(),
+                LocationTag = locationTag ?? new LocationTag()
+            });
+        }
 
         var userViewModel = new UserViewModel
         {

--- a/Models/EventModel.cs
+++ b/Models/EventModel.cs
@@ -43,12 +43,6 @@ public class Event : BaseModel
 
     [Column("Deleted")]
     public bool Deleted { get; set; } = false;
-    public string CreatorProfileImageUrl { get; set; } = "";
-    public string CreatorDisplayName { get; set; } = "";
-    public int CurrentParticipant { get; set; } = 0;
-    public EventCategoryTag EventCategoryTag { get; set; } = new();
-
-
 }
 
 [Table("EVENT_QUESTION")]

--- a/Services/EventService.cs
+++ b/Services/EventService.cs
@@ -143,11 +143,7 @@ public class EventService(Client supabaseClient, UserService userService)
                     EventDate = e.EventDate,
                     PostExpiryDate = e.PostExpiryDate,
                     CreatedAt = e.CreatedAt,
-                    Deleted = e.Deleted,
-                    CreatorProfileImageUrl = creator?.ProfileImageUrl ?? "",
-                    CreatorDisplayName = creator?.DisplayName ?? "",
-                    CurrentParticipant = e.CurrentParticipant,
-                    EventCategoryTag = categoryTag ?? new EventCategoryTag()
+                    Deleted = e.Deleted
                 });
             }
         }


### PR DESCRIPTION
This pull request includes several changes to improve the data handling and structure in the `UserController`, `EventModel`, and `EventService`. The most important changes involve refactoring how event data is processed and removing redundant properties from the `Event` model.

Improvements to event data processing:

* [`Controllers/UserController.cs`](diffhunk://#diff-063dfe89fcca143f4d2d81b0786555bd22dc43a0cdbf3b48eb04858636ffbaf3L132-R155): Changed the method `Profile` to fetch additional data like `creator`, `eventTag`, and `locationTag` for each event, and added these details to `EventBriefCardData`. This ensures that the event cards have more comprehensive data.

Code simplification:

* [`Models/EventModel.cs`](diffhunk://#diff-c33d25cdb9e49a70d757fecc2a07fcde66e3eb1f7eeb56f6c8645d2d53a530d1L46-L51): Removed redundant properties `CreatorProfileImageUrl`, `CreatorDisplayName`, `CurrentParticipant`, and `EventCategoryTag` from the `Event` model to streamline the data model.
* [`Services/EventService.cs`](diffhunk://#diff-3e2c0330882956c079832f6c2824220fdae2cfbcace46d9321193e840e2d613fL146-R146): Updated the method `GetEventsByUserId` to remove the fetching and assignment of the now-removed properties from the `Event` model.