### PR TITLE
Fix/exclude expired posts explore

### DIFF
--- a/Models/EventModel.cs
+++ b/Models/EventModel.cs
@@ -43,6 +43,9 @@ public class Event : BaseModel
 
     [Column("Deleted")]
     public bool Deleted { get; set; } = false;
+
+    [Column("Status")]
+    public string Status { get; set; } = "active";
 }
 
 [Table("EVENT_QUESTION")]

--- a/Models/EventModel.cs
+++ b/Models/EventModel.cs
@@ -43,9 +43,6 @@ public class Event : BaseModel
 
     [Column("Deleted")]
     public bool Deleted { get; set; } = false;
-
-    [Column("Status")]
-    public string Status { get; set; } = "active";
 }
 
 [Table("EVENT_QUESTION")]

--- a/Services/EventService.cs
+++ b/Services/EventService.cs
@@ -333,6 +333,7 @@ public class EventService(Client supabaseClient, UserService userService)
         var response = await _supabaseClient
             .From<Event>()
             .Filter(row => row.Deleted, Supabase.Postgrest.Constants.Operator.Equals, "false")
+            .Filter(row => row.PostExpiryDate, Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.UtcNow)
             .Order("CreatedAt", Supabase.Postgrest.Constants.Ordering.Descending)
             .Range(from, to)
             .Get();
@@ -463,6 +464,8 @@ public class EventService(Client supabaseClient, UserService userService)
             .From<Event>()
             .Select("*")
             .Filter("EventCategoryTagId", Supabase.Postgrest.Constants.Operator.Equals, tagId.ToString())
+            .Filter("Deleted", Supabase.Postgrest.Constants.Operator.Equals, "false")
+            .Filter("PostExpiryDate", Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.UtcNow)
             .Order("CreatedAt", Supabase.Postgrest.Constants.Ordering.Descending)
             .Get();
 

--- a/Services/EventService.cs
+++ b/Services/EventService.cs
@@ -334,6 +334,7 @@ public class EventService(Client supabaseClient, UserService userService)
             .From<Event>()
             .Filter(row => row.Deleted, Supabase.Postgrest.Constants.Operator.Equals, "false")
             .Filter(row => row.PostExpiryDate, Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ssZ"))
+            .Filter(row => row.Status, Supabase.Postgrest.Constants.Operator.Equals, "active")
             .Order("CreatedAt", Supabase.Postgrest.Constants.Ordering.Descending)
             .Range(from, to)
             .Get();
@@ -466,6 +467,7 @@ public class EventService(Client supabaseClient, UserService userService)
             .Filter("EventCategoryTagId", Supabase.Postgrest.Constants.Operator.Equals, tagId.ToString())
             .Filter("Deleted", Supabase.Postgrest.Constants.Operator.Equals, "false")
             .Filter(row => row.PostExpiryDate, Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ssZ"))
+            .Filter(row => row.Status, Supabase.Postgrest.Constants.Operator.Equals, "active")
             .Order("CreatedAt", Supabase.Postgrest.Constants.Ordering.Descending)
             .Get();
 

--- a/Services/EventService.cs
+++ b/Services/EventService.cs
@@ -333,7 +333,7 @@ public class EventService(Client supabaseClient, UserService userService)
         var response = await _supabaseClient
             .From<Event>()
             .Filter(row => row.Deleted, Supabase.Postgrest.Constants.Operator.Equals, "false")
-            .Filter(row => row.PostExpiryDate, Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.UtcNow)
+            .Filter(row => row.PostExpiryDate, Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ssZ"))
             .Order("CreatedAt", Supabase.Postgrest.Constants.Ordering.Descending)
             .Range(from, to)
             .Get();
@@ -465,7 +465,7 @@ public class EventService(Client supabaseClient, UserService userService)
             .Select("*")
             .Filter("EventCategoryTagId", Supabase.Postgrest.Constants.Operator.Equals, tagId.ToString())
             .Filter("Deleted", Supabase.Postgrest.Constants.Operator.Equals, "false")
-            .Filter("PostExpiryDate", Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.UtcNow)
+            .Filter(row => row.PostExpiryDate, Supabase.Postgrest.Constants.Operator.GreaterThan, DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ssZ"))
             .Order("CreatedAt", Supabase.Postgrest.Constants.Ordering.Descending)
             .Get();
 


### PR DESCRIPTION
This pull request introduces changes to the `Event` model and the `EventService` to improve event filtering and management. The most important changes include adding a new `Status` property to the `Event` model, and updating the event retrieval methods to filter out expired and inactive events.

Updates to event retrieval methods:

* Updated `GetPaginatedEvents` method to filter out events that are expired or inactive. (`Services/EventService.cs`)
* Updated `GetEventsByTagId` method to filter out events that are deleted, expired, or inactive. (`Services/EventService.cs`)